### PR TITLE
Update exit system and refactor WeaponTray UI

### DIFF
--- a/Content/UI/InGame/WeaponUI/Widgets/WeaponTray.uasset
+++ b/Content/UI/InGame/WeaponUI/Widgets/WeaponTray.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d21e8e202a4596d6a9b80a78fae33f0af12bf06d218af0bee5870aed3e596d1d
-size 106907
+oid sha256:613eedd06f0c1c84307f2f64599cde2f45e3df2dd2e1612dfac1194b6f8e0b70
+size 52846

--- a/Source/PPP/Characters/PppPlayerController.h
+++ b/Source/PPP/Characters/PppPlayerController.h
@@ -66,7 +66,7 @@ public:
     UUserWidget* MainMenuWidgetInstance;
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI")
     UUserWidget* PauseMenuWidgetInstance;
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Transient, Category = "UI")
     UUserWidget* GameOverWidgetInstance;
 
     // ====== 사운드 ======
@@ -88,6 +88,9 @@ public:
     void ShowGameOver();
     UFUNCTION()
     void OnCharacterDead();
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Stage")
+    FName StageLevelName = TEXT("Stage2");
+
 private:
     UFUNCTION()
     void HandlePauseKey();

--- a/Source/PPP/GameMode/PPPGameMode.h
+++ b/Source/PPP/GameMode/PPPGameMode.h
@@ -4,7 +4,7 @@
 #include "GameFramework/GameMode.h"
 #include "DummyEnemy.h"
 #include "GameDefines.h"
-#include "PPPGameState.h" // ✅ GameState 클래스 참조 추가
+#include "PPPGameState.h" // GameState 클래스 참조 추가
 #include "../Ai/PppBaseAICharacter.h" // Base AI Character
 #include "Blueprint/UserWidget.h" // 정현성 타임 UI 추가
 #include "PPPGameMode.generated.h"
@@ -69,6 +69,22 @@ public:
 
     UPROPERTY(BlueprintAssignable, Category="Round")
     FOnRoundClearedSignal OnRoundClearedSignal;
+
+    // 여우리
+    // 라운드 클리어 직후 출구 제한시간 시작 (시간 내 못 들어가면 GameOver)
+    UFUNCTION(BlueprintCallable, Category="Stage")
+    void StartExitWindow();
+
+    // 코드 추가한 범인은 바로.... <김여울>
+    // 게이트 겹침 시 호출(트리거나 BP에서 호출)
+    UFUNCTION(BlueprintCallable, Category="Gate")
+    void EnterNextStage();
+
+    // 김여울
+    // 출구 제한시간 초과 시(GameState에서 콜백)
+    UFUNCTION()
+    void OnExitTimeOver();
+
 protected:
 
     // 현재 라운드 번호
@@ -119,4 +135,21 @@ protected:
     // 타임 위젯 블루프린트 클래스
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UI")
     TSubclassOf<UUserWidget> TimeWidgetClass;
+
+    // 김여울
+    // 출구 제한시간 기본값(클리어 후 StartExitWindow 호출 시 쓰는 값)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Gate|Timer", meta=(ClampMin="1.0"))
+    float ExitWindowSeconds = 30.f;
+
+    // 태그로 씬의 게이트 찾기(BP 트리거나 액터에 "StageGate" 태그 부여)
+    UPROPERTY(EditAnywhere, Category="Gate")
+    FName ExitGateTag = TEXT("StageGate");
+
+    // 씬의 게이트 참조(자동 캐싱)
+    UPROPERTY(VisibleAnywhere, Category="Gate")
+    AActor* ExitGate = nullptr;
+
+    // 출구 오픈 상태
+    UPROPERTY(VisibleAnywhere, Category="Gate")
+    bool bGateOpen = false;
 };

--- a/Source/PPP/InGame/WeaponTray.h
+++ b/Source/PPP/InGame/WeaponTray.h
@@ -43,8 +43,7 @@ public:
     UFUNCTION(BlueprintCallable, Category = "UI")
     void UpdateWeaponInfo(const FText& NewWeaponName, UTexture2D* NewWeaponImage);
 
-    // 탄약 정보를 업데이트 하는 함수
-    UFUNCTION(BlueprintCallable, Category = "UI")
+    UFUNCTION(BlueprintCallable, Category="UI")
     void UpdateAmmoText(int32 NewAmmoInMag, int32 NewReserveAmmo);
 
 protected:
@@ -52,25 +51,21 @@ protected:
     UPROPERTY(meta = (BindWidget))
     TObjectPtr<UTextBlock> WeaponNameText;
     UPROPERTY(meta = (BindWidget))
-    TObjectPtr<UImage> PrimaryWeaponImage;
-    UPROPERTY(meta = (BindWidget))
-    TObjectPtr<UImage> SecondaryWeaponImage;
+    TObjectPtr<UImage> WeaponImage;
     UPROPERTY(meta = (BindWidget))
     TObjectPtr<UTextBlock> CurrentAmmoText;
     UPROPERTY(meta = (BindWidget))
     TObjectPtr<UTextBlock> ReserveAmmoText;
     UPROPERTY(meta = (BindWidget))
     TObjectPtr<UTextBlock> FireModeText;
-    UPROPERTY(meta=(BindWidget))
-    TObjectPtr<UImage> AmmoImage;
 
     // 시작 시 숨김/표시 전환용 루트
     UPROPERTY(meta=(BindWidgetOptional))
     TObjectPtr<UWidget> TrayAnchor;
 
     // 애니메이션 바인딩
-    UPROPERTY(meta = (BindWidgetAnim), Transient)
-    UWidgetAnimation* WeaponSwap = nullptr;
+    // UPROPERTY(meta = (BindWidgetAnim), Transient)
+    // UWidgetAnimation* WeaponSwap = nullptr;
 
 private:
     // 델리게이트 바인드용
@@ -83,16 +78,8 @@ private:
     // Fire Mode UI 갱신
     void UpdateFireModeTextFromWeapon(AEquipWeaponMaster* Weapon);
 
-    // 아이콘 세터
-    UFUNCTION(BlueprintCallable, Category="UI")
-    void SetAmmoIcon(UTexture2D* NewAmmoImage);
-
     // 캐릭터 참조를 저장
     UPROPERTY() APppCharacter* CachedCharacter = nullptr;
-
-    // 직전 무기 아이콘 (Secondary Weapon Image 용)
-    UPROPERTY(Transient)
-    TObjectPtr<UTexture2D> LastIcon = nullptr;
 
     // 무기 보유 여부 가드
     bool bHasWeapon = false;

--- a/Source/PPP/OutGame/GameOverWidget.cpp
+++ b/Source/PPP/OutGame/GameOverWidget.cpp
@@ -11,14 +11,17 @@ void UGameOverWidget::NativeConstruct()
     {
         Return_BTN->OnClicked.AddDynamic(this, &UGameOverWidget::OnReturnToMainMenuClicked);
     }
+}
 
-    // 캐릭터의 델리게이트를 바인딩해서 로그 찍어보기 -> GameMode에서 바인딩되면 이부분 삭제
-    /*
-    if (APppCharacter* PlayerChar = Cast<APppCharacter>(UGameplayStatics::GetPlayerCharacter(this, 0)))
+void UGameOverWidget::NativeDestruct
+(
+)
+{
+    if (Return_BTN)
     {
-        PlayerChar->OnCharacterDead.AddDynamic(this, &UGameOverWidget::HandlePlayerDeath);
+        Return_BTN->OnClicked.RemoveDynamic(this, &UGameOverWidget::OnReturnToMainMenuClicked);
     }
-    */
+    Super::NativeDestruct();
 }
 
 void UGameOverWidget::OnReturnToMainMenuClicked()

--- a/Source/PPP/OutGame/GameOverWidget.h
+++ b/Source/PPP/OutGame/GameOverWidget.h
@@ -18,6 +18,7 @@ class PPP_API UGameOverWidget : public UUserWidget
 
 protected:
     virtual void NativeConstruct() override;
+    virtual void NativeDestruct() override;
 
     UFUNCTION()
     void OnReturnToMainMenuClicked();


### PR DESCRIPTION
### Description

This pull request includes the following:

1. **New Exit Mechanics**
   - Added a post-clear exit feature with a timer to increase gameplay tension.
   - Introduced `StartExitWindow` to initiate the timer and handle gate opening after stage clear.
   - Implemented `OnExitTimeOver` to trigger Game Over when the timer expires.
   - Added `EnterNextStage` for progressing to the next stage upon timely exit.
   - Enhanced interaction between `PPPGameMode` and `PPPGameState` to integrate new mechanics.
   - Added logic and tags for handling the exit gate and timer functionality.

2. **Refactored WeaponTray Code**
   - Unified `PrimaryWeaponImage`, `SecondaryWeaponImage`, and `AmmoImage` into a single `WeaponImage`.
   - Removed redundant icons, caching, and update logic for better readability.
   - Simplified `NativeDestruct` and removed duplicate checks.
   - Updated `WeaponTray.uasset` to reflect code adjustments