### PR TITLE
Add game instance for weapon state and enhance game timers

### DIFF
--- a/Content/GameMode/Blueprints/BP_PPPGameMode.uasset
+++ b/Content/GameMode/Blueprints/BP_PPPGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b8a726a5244d2ba882bc2252dbed299427b30695ee8c92e643f48f62821ebbc
-size 22192
+oid sha256:0f0d78c2624d1f848c6fb69ec912a60d080d7be052aabe5474b3eca2e4422c90
+size 22484

--- a/Content/GameMode/Blueprints/BP_PPPGameMode_Stage1.uasset
+++ b/Content/GameMode/Blueprints/BP_PPPGameMode_Stage1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6930cfb7493a194382d73e31234a05b0f7adfc82f101a20c62a5430041e741a1
+size 21491

--- a/Content/GameMode/Blueprints/BP_PPPGameMode_Stage1.uasset
+++ b/Content/GameMode/Blueprints/BP_PPPGameMode_Stage1.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6930cfb7493a194382d73e31234a05b0f7adfc82f101a20c62a5430041e741a1
-size 21491

--- a/Content/Maps/Stage1.umap
+++ b/Content/Maps/Stage1.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:690ec3fb2341370c852ef85ab21dcab2baf5febf1caa4232854d6cc3b631855a
+oid sha256:968233f355c2602857ddecc5e3f13924db6480813453a6acacb1d991d8b55ba9
 size 2040160

--- a/Content/Maps/Stage2.umap
+++ b/Content/Maps/Stage2.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7963a7e0c9f6d3a16a44b90f3359b8b107756ab0c79bfa062aad71b06f0edba9
-size 2519279
+oid sha256:1168ae1010796d58cda2095c1b3996a62a79c7ab755bc73e16fb5d05f484942d
+size 2517929

--- a/Source/PPP/Ai/BTService_FleeDetectPlayer.cpp
+++ b/Source/PPP/Ai/BTService_FleeDetectPlayer.cpp
@@ -55,12 +55,12 @@ void UBTService_FleeDetectPlayer::TickNode(UBehaviorTreeComponent& OwnerComp, ui
     {
         BlackboardComp->SetValueAsBool(PlayerDetectedKey.SelectedKeyName, true);
         BlackboardComp->SetValueAsVector(PlayerLocationKey.SelectedKeyName, PlayerPawn->GetActorLocation());
-        UE_LOG(LogTemp, Warning, TEXT("FleeAI: Player DETECTED within %.2f. Distance: %.2f"), ActualDetectionRadius, DistanceToPlayer);
+        //UE_LOG(LogTemp, Warning, TEXT("FleeAI: Player DETECTED within %.2f. Distance: %.2f"), ActualDetectionRadius, DistanceToPlayer);
     }
     else
     {
         BlackboardComp->ClearValue(PlayerDetectedKey.SelectedKeyName);
         BlackboardComp->ClearValue(PlayerLocationKey.SelectedKeyName);
-        UE_LOG(LogTemp, Warning, TEXT("FleeAI: Player NOT DETECTED. Distance: %.2f"), DistanceToPlayer);
+        //UE_LOG(LogTemp, Warning, TEXT("FleeAI: Player NOT DETECTED. Distance: %.2f"), DistanceToPlayer);
     }
 }

--- a/Source/PPP/Characters/PPPCharacter.cpp
+++ b/Source/PPP/Characters/PPPCharacter.cpp
@@ -230,7 +230,7 @@ void APppCharacter::StartSprint(const FInputActionValue& value)
     if (GetCharacterMovement())
     {
         GetCharacterMovement()->MaxWalkSpeed = SprintSpeed;
-        UE_LOG(LogTemp, Warning, TEXT("Fast : %f"), GetCharacterMovement()->MaxWalkSpeed);
+        //UE_LOG(LogTemp, Warning, TEXT("Fast : %f"), GetCharacterMovement()->MaxWalkSpeed);
     }
 }
 void APppCharacter::StopSprint(const FInputActionValue& value)
@@ -238,7 +238,7 @@ void APppCharacter::StopSprint(const FInputActionValue& value)
     if (GetCharacterMovement())
     {
         GetCharacterMovement()->MaxWalkSpeed = NormalSpeed;
-        UE_LOG(LogTemp, Warning, TEXT("Slow : %f"), GetCharacterMovement()->MaxWalkSpeed);
+        //UE_LOG(LogTemp, Warning, TEXT("Slow : %f"), GetCharacterMovement()->MaxWalkSpeed);
     }
 }
 void APppCharacter::ZoomIn(const FInputActionValue& value)

--- a/Source/PPP/GameMode/PPPGameMode.h
+++ b/Source/PPP/GameMode/PPPGameMode.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameMode.h"
+#include "GameFramework/GameModeBase.h"
 #include "DummyEnemy.h"
 #include "GameDefines.h"
 #include "PPPGameState.h" // GameState 클래스 참조 추가
@@ -18,6 +19,10 @@ public:
 	APPPGameMode();
 
 	virtual void BeginPlay() override;
+
+    // [탁] 라운드 기본 시간(초). 레벨별로 BeginPlay에서 세팅.
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Round|Timer")
+    float RoundTimePerRound = 60.f; // 기본 60초 (Stage1 용)
 
     // 현재 라운드 번호 반환
     UFUNCTION(BlueprintCallable, Category="Round")
@@ -85,7 +90,16 @@ public:
     UFUNCTION()
     void OnExitTimeOver();
 
+    // [탁] 레벨 로드시 자동 라운드 시작 여부
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Round|AutoStart")
+    bool bAutoStartRoundOnLevelLoad = true;
+
+    // [탁] 자동 시작을 적용할 레벨 이름 목록(소문자 권장: "stage1", "stage2")
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Round|AutoStart")
+    TArray<FName> AutoStartLevels;
+
 protected:
+
 
     // 현재 라운드 번호
     UPROPERTY(VisibleAnywhere, Category="Round")
@@ -152,4 +166,10 @@ protected:
     // 출구 오픈 상태
     UPROPERTY(VisibleAnywhere, Category="Gate")
     bool bGateOpen = false;
+
+    // 디테일창 값(ExitWindowSeconds)을 우선 사용할지 여부
+    // false면: 디테일창 값 그대로 사용
+    // true면 : BeginPlay에서 맵 이름으로 ExitWindowSeconds를 덮어씀
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Round|Timer")
+    bool bOverrideExitSecondsByLevel = false;
 };

--- a/Source/PPP/GameMode/PPPGameState.cpp
+++ b/Source/PPP/GameMode/PPPGameState.cpp
@@ -37,6 +37,18 @@ void APPPGameState::SetRemainingEnemies(int32 Count)
 {
 	RemainingEnemies = Count;
 }
+void APPPGameState::BeginPlay()
+{
+    Super::BeginPlay();
+
+    UE_LOG(LogTemp, Warning, TEXT("[GS] BeginPlay: %s  CanEverTick=%s"),
+        *GetClass()->GetName(),
+        PrimaryActorTick.bCanEverTick ? TEXT("true") : TEXT("false"));
+
+    // 혹시 비활성일 수 있어 강제 Enable
+    SetActorTickEnabled(true);
+    UE_LOG(LogTemp, Warning, TEXT("[GS] TickEnabled=%s"), IsActorTickEnabled() ? TEXT("true") : TEXT("false"));
+}
 
 // -------------------------------
 // Getter 함수들 정의
@@ -85,15 +97,21 @@ void APPPGameState::StartRoundTimer(float Duration)
     bIsTimerRunning = true;
     bTimedOut = false; //시작시 리셋
     PreviousDisplaySeconds = -1;  //표시될 초 리셋
+    UE_LOG(LogTemp, Warning, TEXT("[GS] StartRoundTimer: Duration=%.2f"), RemainingTime);
+
+
 }
 
 void APPPGameState::StopRoundTimer()
 {
     bIsTimerRunning = false;
+    UE_LOG(LogTemp, Warning, TEXT("[GS] StopRoundTimer: Remain=%.2f"), RemainingTime);
+
 }
 
 void APPPGameState::OnRoundTimerFinished()
 {
+    UE_LOG(LogTemp, Warning, TEXT("[GS] TimerFinished 호출"));
     UE_LOG(LogGame, Warning, TEXT("라운드 제한 시간 종료됨"));
 
     bIsTimerRunning = false; //타이머 중단
@@ -129,7 +147,7 @@ void APPPGameState::Tick(float DeltaTime)
         if (CurrentSeconds != PreviousDisplaySeconds)
         {
             PreviousDisplaySeconds = CurrentSeconds;
-            //UE_LOG(LogGame, Log, TEXT("Tick 작동 중 - 남은 시간(초): %d"), CurrentSeconds);
+            UE_LOG(LogTemp, Log, TEXT("[GS:Tick] 남은 시간: %d초 (%.2f)"), CurrentSeconds, RemainingTime);
         }
         // 화면에 표시  정현성 UI 충돌 때문에 주석 처리
         //if (GEngine)

--- a/Source/PPP/GameMode/PPPGameState.h
+++ b/Source/PPP/GameMode/PPPGameState.h
@@ -13,6 +13,10 @@ class PPP_API APPPGameState : public AGameState
 public:
 	APPPGameState();
 
+    // [추가] 타이머 로그를 켜고 끄는 스위치
+    UPROPERTY(EditAnywhere, Category="Round|Debug")
+    bool bDebugTimerLogs = true;
+
 	/** 현재 게임 상태 (InProgress, GameOver 같은 거) */
 	UPROPERTY(BlueprintReadOnly, Category="State")
 	EGameState CurrentState;
@@ -66,6 +70,8 @@ public:
 
     UFUNCTION(BlueprintPure, Category="Timer")
     bool HasTimedOut() const { return bTimedOut; }//스테이지 타임아웃 여부
+
+    virtual void BeginPlay() override; // [로그용] 실제로 GS가 뜨는지 확인
 
 private:
     UPROPERTY(VisibleAnywhere, Category="Timer")

--- a/Source/PPP/Private/PPPGameInstance.cpp
+++ b/Source/PPP/Private/PPPGameInstance.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PPPGameInstance.h"
+

--- a/Source/PPP/Public/PPPGameInstance.h
+++ b/Source/PPP/Public/PPPGameInstance.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Engine/GameInstance.h"
+#include "PPPGameInstance.generated.h"
+
+// 맵 이동 사이에 유지할 최소 정보만 담는다(무기 클래스 등)
+UCLASS()
+class PPP_API UPPPGameInstance : public UGameInstance
+{
+    GENERATED_BODY()
+public:
+    // 현재 장착 무기 클래스(맵 전환 후 재스폰용)
+    UPROPERTY(BlueprintReadWrite)
+    TSubclassOf<AActor> SavedEquippedWeaponClass = nullptr;
+
+    // 필요하면 탄약/강화수치 등도 여기에 추가 가능
+    UPROPERTY(BlueprintReadWrite)
+    int32 SavedAmmo = -1;
+
+    UFUNCTION(BlueprintCallable)
+    void SetEquippedWeaponClass(TSubclassOf<AActor> InClass) { SavedEquippedWeaponClass = InClass; }
+
+    UFUNCTION(BlueprintCallable)
+    TSubclassOf<AActor> GetEquippedWeaponClass() const { return SavedEquippedWeaponClass; }
+};


### PR DESCRIPTION
### Description

This pull request introduces two major updates:
1. **Game Instance for Weapon State Preservation**:
   - Added `UPPPGameInstance` class inheriting from `UGameInstance` to retain weapon state (e.g., class and ammo count) during map transitions.
   - Implemented `SetEquippedWeaponClass` and `GetEquippedWeaponClass` functions for storing and retrieving weapon states.
   - Marked relevant variables and functions as `BlueprintReadWrite` or `BlueprintCallable` for Blueprint accessibility.
   - Removed unnecessary file `BP_PPPGameMode_Stage1.uasset` for cleanup.

2. **Timer Functionality Expansion**:
   - Enhanced `BeginPlay` logic to initialize `ExitWindowSeconds` and `bUseStageTimer` based on the current level.
   - Introduced an `AutoStartLevels` array to enable automatic round starts for specified levels.
   - Added `bDebugTimerLogs` switch for flexible debugging and extended related debug logs.
   - Revised Stage2 timer logic for consistency and unified functionality using `ExitWindowSeconds`.
   - Refactored `PPPGameMode` and `PPPGameState` for improved manageability and debugging convenience.