### PR TITLE
Add score change events and improve score UI logic

### DIFF
--- a/Content/Assets/Character/PPPAssets/Robot_scout_R_21/Blueprints/BP_ThirdPersonGameMode.uasset
+++ b/Content/Assets/Character/PPPAssets/Robot_scout_R_21/Blueprints/BP_ThirdPersonGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3db7ba63058a7e5600587d127dfcbdcf09dec32faca0d9e59207707d42d6dbe
-size 16318
+oid sha256:4da7f4f8e6b7001496ee1c79a5d9ebb1eecd513dcf045378b39b89d613caa6f9
+size 16214

--- a/Content/Character/Blueprints/BP_PppCharacter.uasset
+++ b/Content/Character/Blueprints/BP_PppCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d08e620bfb7124c75f5ffd20e4fcda7b759e23b59027352da069aa52286aa0e8
-size 185738
+oid sha256:aead9d6428cc8c607bacdffa6fe47f9f3c443e5c9cbbc701c4c50b70fd8a3943
+size 183232

--- a/Content/GameMode/Blueprints/BP_PPPGameMode.uasset
+++ b/Content/GameMode/Blueprints/BP_PPPGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6e05c56a5c421de197c6fa0f2d6c3a921bed83c85e0c7cc7d28e835d1a28fe4
-size 23274
+oid sha256:74381748938ed89a727698181cbe514e7b030c1fdf493cd28fb6409bc73b398f
+size 23458

--- a/Content/UI/InGame/HUDClass.uasset
+++ b/Content/UI/InGame/HUDClass.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:301ed704488654388a2d5e87141c7975e28deab4af1170dbc769247485be5633
+size 205342

--- a/Content/UI/InGame/HealthBar/HUDClass.uasset
+++ b/Content/UI/InGame/HealthBar/HUDClass.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8466ed6648dd30fd3f73edf3e68e7535bebc707157a01deabd44a3327ce40540
-size 192192

--- a/Content/UI/InGame/HealthBar/Health.uasset
+++ b/Content/UI/InGame/HealthBar/Health.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2deeba4b6d8a777dc4ba4e4ada7bd38aebec016b936ee67b89de473fd47bd96a
-size 116129
+oid sha256:593d982e9c6d0178e59c624e2c8601ae3e4b9bcdc8d121ca7bbba36519591901
+size 115991

--- a/Content/UI/InGame/HealthBar/HealthBar.uasset
+++ b/Content/UI/InGame/HealthBar/HealthBar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3be71fb9b9743c2fdad7207b21eb641f870e40c9a72762181cac61e0bf557a44
-size 78358
+oid sha256:42e9aad591bda13faae0fab3d50ac8c6314b9c6cce4a7e82a151b2f95b0a9a74
+size 74989

--- a/Content/UI/InGame/Quest/TestQuest/WBP_TestQuest.uasset
+++ b/Content/UI/InGame/Quest/TestQuest/WBP_TestQuest.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05f9c6246d7a1a95264c62a952eae39aba3d876b8f837aa777caf776e14dfbad
-size 75023
+oid sha256:d56816dce915ac4a1adee0d799be82209f2c5b544e5bd5c63ff4fda880496aee
+size 76654

--- a/Content/UI/InGame/Score/WBP_Score.uasset
+++ b/Content/UI/InGame/Score/WBP_Score.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0dc4ce99781ed42372e78d85bdd04a36a91e3ad0ebccc31235ab7d333a94cd7c
-size 19364
+oid sha256:49d27da3c69364dd309875910f92761498b5d77c725175ed53ba4d0bb2cd4047
+size 51918

--- a/Content/UI/InGame/TimeWidget/WBP_Time.uasset
+++ b/Content/UI/InGame/TimeWidget/WBP_Time.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf2cf0df1c119519b58eb87677e7bdb03de419058580d2b26f24fbfeff3576ef
-size 50825
+oid sha256:cfca67ca80ed23cb285fa180f1f0a926b1d51700c4ac8d61a871ae9027853ff4
+size 49921

--- a/Content/UI/InGame/WeaponUI/Widgets/WeaponTray.uasset
+++ b/Content/UI/InGame/WeaponUI/Widgets/WeaponTray.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:613eedd06f0c1c84307f2f64599cde2f45e3df2dd2e1612dfac1194b6f8e0b70
-size 52846
+oid sha256:ecf9f5d9a64a5e53244bf9d6b7af570a8643db6ed24560a21c65f9192a8c375c
+size 52429

--- a/Source/PPP/GameMode/PPPGameMode.cpp
+++ b/Source/PPP/GameMode/PPPGameMode.cpp
@@ -82,6 +82,17 @@ void APPPGameMode::BeginPlay()
 {
     Super::BeginPlay();
 
+    // 정현성 스코어위젯 띄우기
+    if (ScoreWidgetClass)
+    {
+        UUserWidget* ScoreWidget = CreateWidget<UUserWidget>(GetWorld(), ScoreWidgetClass);
+        if (ScoreWidget)
+        {
+            ScoreWidget->AddToViewport();
+            UE_LOG(LogTemp, Warning, TEXT("ScoreWidget created and added to viewport"));
+        }
+    }
+
     // ===== [추가] 레벨별 라운드 기본 시간/모드 설정 (Stage1=60초, Stage2=120초) =====
 
     const FString Lraw = UGameplayStatics::GetCurrentLevelName(this, /*bRemovePrefixString=*/true);
@@ -349,30 +360,30 @@ void APPPGameMode::OnEnemyKilled()
         QuestComponent->OnEnemyKilled(1);
     }
 
-    const int32 NewCount = FMath::Max(GS->RemainingEnemies - 1, 0);
-    GS->SetRemainingEnemies(NewCount);
-
-    UE_LOG(LogEnemy, Log, TEXT("적 처치! 남은 적: %d, 현재 점수: %d"), NewCount, GS->GetScore());
-
-    CheckRewardCondition();
-
-    const FString LevelName = UGameplayStatics::GetCurrentLevelName(this, true);
-    if (LevelName.Contains(TEXT("Stage1")) || LevelName.Contains(TEXT("stage1")))
-    {
-        UE_LOG(LogEnemy, Log, TEXT("Stage1 - 처치만으로 라운드 종료 안 함."));
-        return;
-    }
-
-    if (NewCount <= 0)
-    {
-        UE_LOG(LogEnemy, Log, TEXT("모든 적 처치! 라운드 종료"));
-        EndRound();
-    }
-    else
-    {
-        UE_LOG(LogEnemy, Log, TEXT("라운드 진행 중 - 남은 적: %d"), NewCount);
-    }
-}
+    // const int32 NewCount = FMath::Max(GS->RemainingEnemies - 1, 0);
+    // GS->SetRemainingEnemies(NewCount);
+//
+    // UE_LOG(LogEnemy, Log, TEXT("적 처치! 남은 적: %d, 현재 점수: %d"), NewCount, GS->GetScore());
+//
+    // CheckRewardCondition();
+//
+    // const FString LevelName = UGameplayStatics::GetCurrentLevelName(this, true);
+    // if (LevelName.Contains(TEXT("Stage1")) || LevelName.Contains(TEXT("stage1")))
+    // {
+    //     UE_LOG(LogEnemy, Log, TEXT("Stage1 - 처치만으로 라운드 종료 안 함."));
+    //     return;
+    // }
+//
+    // if (NewCount <= 0)
+    // {
+    //     UE_LOG(LogEnemy, Log, TEXT("모든 적 처치! 라운드 종료"));
+    //     EndRound();
+    // }
+    // else
+    // {
+    //     UE_LOG(LogEnemy, Log, TEXT("라운드 진행 중 - 남은 적: %d"), NewCount);
+    // }
+}//
 void APPPGameMode::OnPlayerDeath()
 {
     UE_LOG(LogGame, Error, TEXT("플레이어 사망"));

--- a/Source/PPP/GameMode/PPPGameMode.h
+++ b/Source/PPP/GameMode/PPPGameMode.h
@@ -75,6 +75,9 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Quest")
     UTestQuestActorComponent* GetQuestComponent() const;
 
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UI")
+    TSubclassOf<UUserWidget> ScoreWidgetClass;
+
 	/** 적 스폰 */
 	void SpawnEnemies();
 

--- a/Source/PPP/GameMode/PPPGameState.cpp
+++ b/Source/PPP/GameMode/PPPGameState.cpp
@@ -4,6 +4,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Engine/World.h"
 #include "TimerManager.h"
+#include "Net/UnrealNetwork.h" // 정현성 DOREPLIFETIME 매크로를 사용하기 위해 이 헤더를 추가해야 한다는데 이해 못함
 
 
 
@@ -74,7 +75,9 @@ int32 APPPGameState::GetRemainingEnemies() const
 // -------------------------------
 void APPPGameState::OnRep_Score()
 {
-    // UI에 연결 예정
+    // 정현성
+    OnScoreChanged.Broadcast(Score);
+    UE_LOG(LogGame, Log, TEXT("Score updated: %d"), Score);
 }
 void APPPGameState::AddScore(int32 Amount)
 {
@@ -86,7 +89,7 @@ void APPPGameState::ResetScore()
 {
     Score = 0;
     OnRep_Score(); // 점수 초기화 시 UI 업데이트
-    UE_LOG(LogGame, Log, TEXT("Score reset to 0"));
+    //UE_LOG(LogGame, Log, TEXT("Score reset to 0"));
 }
 
 bool APPPGameState::IsRoundCleared() const
@@ -178,5 +181,14 @@ void APPPGameState::Tick(float DeltaTime)
         //}
         // 시간이 0 이하로 떨어졌을 경우 라운드 종료 처리
 
-    }
+}
 
+// 정현성
+// 네트워크 복제를 위한 GetLifetimeReplicatedProps 함수 정의?? 잘 모르겠음
+void APPPGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+
+    DOREPLIFETIME(APPPGameState, Score);
+}

--- a/Source/PPP/GameMode/PPPGameState.h
+++ b/Source/PPP/GameMode/PPPGameState.h
@@ -5,6 +5,10 @@
 #include "GameDefines.h"
 #include "PPPGameState.generated.h"
 
+// 정현성
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnScoreChanged, int32, NewScore);
+
+
 UCLASS()
 class PPP_API APPPGameState : public AGameState
 {
@@ -33,13 +37,25 @@ public:
 	/** 남은 적 */
 	UPROPERTY(BlueprintReadOnly, Category="State")
 	int32 RemainingEnemies;
-    /** 점수 */
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Score")
+
+    // 정현성
+    // 점수가 변경될 때마다 함수 자동 호출
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, ReplicatedUsing=OnRep_Score, Category = "Score")
     int32 Score = 0;
+
+    UPROPERTY(BlueprintAssignable, Category = "Score")
+    FOnScoreChanged OnScoreChanged;
+
+    /** 점수 (정현성 주석 처리) */
+    // UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Score")
+    // int32 Score = 0;
+
+
     // 점수로 라운드 클리어 판단
     UFUNCTION(BlueprintCallable)
     bool IsRoundCleared() const;
 
+    // 정현성
     UFUNCTION()
     void OnRep_Score();
 


### PR DESCRIPTION
### Description

This pull request introduces enhancements to the score management system, including event-driven updates for score changes and improvements to the in-game score UI.

#### Key Changes:
- Implemented `FOnScoreChanged` delegate for automatic event calls and UI synchronization upon score changes.
- Added broadcast and log output functionality in `OnRep_Score` during score updates.
- Configured score variable for network replication using the `DOREPLIFETIME` macro.
- Created logic to initialize and add the score widget to the viewport at game start.
- Refactored `PPPGameState` and `PPPGameMode` files to streamline score UI management.
- Updated related blueprint and UI assets.

### Checklist

- [ ] Ensured all new features are tested thoroughly.
- [ ] Verified compatibility with existing features and systems.
- [ ] Confirmed no impact on performance or stability.